### PR TITLE
Fixed the UBIFS file system extraction on python 3 environment

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -36,15 +36,15 @@ APTGETCMD="apt-get"
 YUMCMD="yum"
 if [ $distro = "Kali" ]
 then
-    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract util-linux firmware-mod-kit cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop cpio"
+    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract util-linux firmware-mod-kit cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop cpio zlib1g-dev liblzo2-dev"
 elif [ $distro_version = "17" ]
 then
-    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio"
+    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio zlib1g-dev liblzo2-dev"
 elif [ $distro_version = "18" ]
 then
-    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio"
+    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio zlib1g-dev liblzo2-dev"
 else
-    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsprogs cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio"
+    APT_CANDIDATES="git build-essential libqt4-opengl mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsprogs cramfsswap squashfs-tools zlib1g-dev liblzma-dev liblzo2-dev sleuthkit default-jdk lzop srecord cpio zlib1g-dev liblzo2-dev"
 fi
 PYTHON2_APT_CANDIDATES="python-crypto python-lzo python-lzma python-pip python-tk"
 PYTHON3_APT_CANDIDATES="python3-crypto python3-pip python3-tk"
@@ -118,11 +118,12 @@ function install_cramfstools
 
 function install_ubireader
 {
+    install_pip_package python-lzo
     git clone https://github.com/jrspruitt/ubi_reader
     # Some UBIFS extraction breaks after this commit, due to "Added fatal error check if UBI block extends beyond file size"
     # (see this commit: https://github.com/jrspruitt/ubi_reader/commit/af678a5234dc891e8721ec985b1a6e74c77620b6)
     # Reset to a known working commit.
-    (cd ubi_reader && git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51 && $SUDO python setup.py install)
+    (cd ubi_reader && $SUDO python setup.py install)
     $SUDO rm -rf ubi_reader
 }
 

--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -78,8 +78,8 @@
 ^jffs2 filesystem:jffs2:jefferson -d '%%jffs2-root%%' '%e':0:False
 
 # Use ubi_reader tool for UBIFS extraction
-^ubifs filesystem superblock node:ubi:ubireader_extract_files -o '%%ubifs-root%%' '%e':0:False
-^ubi erase count header:ubi:ubireader_extract_files -o '%%ubifs-root%%' '%e':0:False
+^ubifs filesystem superblock node:ubi:ubireader_extract_files -w -o '%%ubifs-root%%' '%e':0:False
+^ubi erase count header:ubi:ubireader_extract_files -w -o '%%ubifs-root%%' '%e':0:False
 
 # Experimental yaffs extractor
 ^yaffs filesystem:yaffs:yaffshiv --auto --brute-force -f '%e' -d '%%yaffs-root%%':0:False


### PR DESCRIPTION
Solution :
synced up with the latest version of the ubi_reader python
package which is already ported to python 3 earlier version
only worked in python 2