### PR TITLE
deps.sh: use new upstream cramfs-tools

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -103,16 +103,14 @@ function install_cramfstools
   INSTALL_LOCATION=/usr/local/bin
 
   # https://github.com/torvalds/linux/blob/master/fs/cramfs/README#L106
-  wget  https://downloads.sourceforge.net/project/cramfs/cramfs/1.1/cramfs-1.1.tar.gz?ts=$TIME -O cramfs-1.1.tar.gz
-  tar xf cramfs-1.1.tar.gz
+  git clone https://github.com/npitre/cramfs-tools
   # There is no "make install"
-  (cd cramfs-1.1 \
+  (cd cramfs-tools \
   && make \
   && $SUDO install mkcramfs $INSTALL_LOCATION \
   && $SUDO install cramfsck $INSTALL_LOCATION)
 
-  rm cramfs-1.1.tar.gz
-  rm -rf cramfs-1.1
+  rm -rf cramfs-tools
 }
 
 


### PR DESCRIPTION
Version 1.1 of cramfs does not build anymore with glibc 2.28 because
since this version glibc no longer includes <sys/sysmacros.h> from
<sys/types.h>, and therefore <sys/sysmacros.h> must be included
explicitly when major()/minor() are used.

To fix this issue, use new upstream project which includes
https://github.com/npitre/cramfs-tools/commit/434aabd67a39165ee0750c0e0d25213bf2ec8fa5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>